### PR TITLE
Use riak_core 1.0.0

### DIFF
--- a/2011/riak-core-conflict-resolution/rts/rebar.config
+++ b/2011/riak-core-conflict-resolution/rts/rebar.config
@@ -3,7 +3,7 @@
 {sub_dirs, ["rel"]}.
 
 {deps, [{riak_core, "1.0.*",
-         {git, "git://github.com/basho/riak_core", "1.0"}},
+         {git, "git://github.com/basho/riak_core", {tag,"1.0.0"}}},
         {statebox, "0.2.1",
          {git, "git://github.com/mochi/statebox.git", {tag, "v0.2.1"}}}
        ]}.

--- a/2011/riak-core-first-multinode/mfmn/rebar.config
+++ b/2011/riak-core-first-multinode/mfmn/rebar.config
@@ -2,6 +2,6 @@
 
 {sub_dirs, ["rel"]}.
 
-{deps, [{riak_core, "0.14..*",
-         {git, "git://github.com/basho/riak_core", "master"}}
+{deps, [{riak_core, "1.0.*",
+         {git, "git://github.com/basho/riak_core", {tag,"1.0.0"}}}
        ]}.

--- a/2011/riak-core-the-coordinator/rts/rebar.config
+++ b/2011/riak-core-the-coordinator/rts/rebar.config
@@ -3,5 +3,5 @@
 {sub_dirs, ["rel"]}.
 
 {deps, [{riak_core, "1.0.*",
-         {git, "git://github.com/basho/riak_core", "1.0"}}
+         {git, "git://github.com/basho/riak_core", {tag,"1.0.0"}}}
        ]}.

--- a/2011/riak-core-the-vnode/rts/rebar.config
+++ b/2011/riak-core-the-vnode/rts/rebar.config
@@ -3,5 +3,5 @@
 {sub_dirs, ["rel"]}.
 
 {deps, [{riak_core, "1.0.*",
-         {git, "git://github.com/basho/riak_core", "1.0"}}
+         {git, "git://github.com/basho/riak_core", {tag,"1.0.0"}}}
        ]}.


### PR DESCRIPTION
i updated the rebar.config files to use riak_core 1.0.0 so that everything works until you have time to update to deal w/ the breaking changes in the 1.0.x branch (what i ran into was the removal of riak_core:register_vnode_module).
