### PR TITLE
Various minor text fixes

### DIFF
--- a/2011/riak-core-conflict-resolution/README.md
+++ b/2011/riak-core-conflict-resolution/README.md
@@ -31,7 +31,7 @@ consistency than I'm talking about here.  No, I'm more interested in
 the _Atomic_ and _Isolated_ parts of the acronym.  It's these parts of
 ACID that give a RDBMS its predictable behavior in the face of
 concurrency.  One transaction cannot affect another concurrent
-transaction (i.e. one can't see the others modifications) and the
+transaction (i.e. one can't see the other's modifications) and the
 **entire** transaction must succeed or fail (i.e. there is no chance
 of partial completion).  This means that modifications are serialized,
 i.e. applied in-full one after another always working with the

--- a/2011/riak-core-conflict-resolution/README.md
+++ b/2011/riak-core-conflict-resolution/README.md
@@ -55,12 +55,12 @@ hands and returns crap data?  Absolutely not, it pushes the
 enforcement of consistency to read time.  Furthermore, it only
 considers consistency in terms of the nodes it can see.  That is, if
 the cluster splits into two then a read won't fail but instead will
-use the data it has access to determine a response.  When the cluster
+use the data to which it has access to determine a response.  When the cluster
 repairs and another read occurs the system will then take that time to
 perform _conflict resolution_ in order to reconcile any
 inconsistencies that were created by the cluster split.  That is, Riak
-and systems like it build atop Riak Core, are lazy in their
-enforcement of consistency.  Choosing to delay it until absolutely
+and systems like it built atop Riak Core, are lazy in their
+enforcement of consistency, choosing to delay it until absolutely
 needed.
 
 Notice I am not saying one is better than the other.  Both have their

--- a/2011/riak-core-conflict-resolution/README.md
+++ b/2011/riak-core-conflict-resolution/README.md
@@ -67,7 +67,7 @@ Notice I am not saying one is better than the other.  Both have their
 place and the ultimate system would allow you to choose the semantics
 of your data storage on an as-needed basis.  To a certain extent Riak
 allows you to do this via its quorum parameters but even something
-like `W = M` (that is, all writes must finish before a call returns)
+like `W = N` (that is, all writes must finish before a call returns)
 doesn't get you the consistency found in RDBMS.  Said as succinctly as
 possible, RDBMS says "all of you [nodes] must agree **right now** or I
 will fail the write" whereas something Riak-like says "at some point

--- a/2011/riak-core-conflict-resolution/README.md
+++ b/2011/riak-core-conflict-resolution/README.md
@@ -29,7 +29,7 @@ _ACID_ (Atomic Consistent Isolated Durable).  Notice the word
 _Consistent_ is baked right into the acronym but that's a different
 consistency than I'm talking about here.  No, I'm more interested in
 the _Atomic_ and _Isolated_ parts of the acronym.  It's these parts of
-ACID that give a RDBMS it's predictable behavior in the face of
+ACID that give a RDBMS its predictable behavior in the face of
 concurrency.  One transaction cannot affect another concurrent
 transaction (i.e. one can't see the others modifications) and the
 **entire** transaction must succeed or fail (i.e. there is no chance
@@ -50,7 +50,7 @@ Riak takes a different approach.  It embraces potential inconsistency
 in return for lower latency and availability.  If a node goes down or
 the network partitions the data is still available for read and write.
 In certain scenarios the data may become inconsistent causing multiple
-concurrent versions to exist.  Does that mean Riak just throws up it's
+concurrent versions to exist.  Does that mean Riak just throws up its
 hands and returns crap data?  Absolutely not, it pushes the
 enforcement of consistency to read time.  Furthermore, it only
 considers consistency in terms of the nodes it can see.  That is, if
@@ -66,7 +66,7 @@ needed.
 Notice I am not saying one is better than the other.  Both have their
 place and the ultimate system would allow you to choose the semantics
 of your data storage on an as-needed basis.  To a certain extent Riak
-allows you to do this via it's quorum parameters but even something
+allows you to do this via its quorum parameters but even something
 like `W = M` (that is, all writes must finish before a call returns)
 doesn't get you the consistency found in RDBMS.  Said as succinctly as
 possible, RDBMS says "all of you [nodes] must agree **right now** or I
@@ -81,7 +81,7 @@ take time for Basho to discover the generalities and encode them in
 Core.  There is the
 [riak_object](https://github.com/basho/riak_kv/blob/1.0/src/riak_object.erl)
 which contains a basic wrapper for storing data in a Riak Core app
-utilizing vector clocks to detect entropy but unfortunately it's
+utilizing vector clocks to detect entropy but unfortunately its
 relevant bits haven't been pulled down to Core yet.  There is also
 work being done by others in this area such as Mochi Media's
 [statebox](https://github.com/mochi/statebox) abstraction which can be
@@ -331,7 +331,7 @@ how to resolve them.
 
 In order to reconcile conflicts in your system you have to know about
 the type of data being stored.  For example, in Riak the data is an
-opaque blob which means Riak can't really do much on it's own to
+opaque blob which means Riak can't really do much on its own to
 resolve a conflict because it doesn't understand anything about the
 data.  By default Riak will implement a _Last Write Wins_ (LWW)
 behavior which will select the latest object version based on wall
@@ -597,7 +597,7 @@ While statebox saves you a lot of trouble it isn't fool proof.  The
 key is that your statebox window must be larger than the partition
 window (it terms of time and number of operations) or else you
 **will** lose events and thus lose data.  Whether that's acceptable
-depends entirely on your specific application and it's data
+depends entirely on your specific application and its data
 requirements.
 
 Returning to the example, statebox would determine that even though
@@ -672,7 +672,7 @@ reconciled object.  I like to refer to this type of anti-entropy as
 _passive anti-entropy_ because it is secondary to some other primary
 action.  This is opposed to _active anti-entropy_ such as background
 gossiped _Merkle Trees_ which is preemptive and a primary action in
-it's own right.
+its own right.
 
 In RTS I added a state for the read coordinator (`rts_get_fsm`) named
 `finalize`.  This state will not be entered until all `N` replies
@@ -720,7 +720,7 @@ help me test and demonstrate my scenarios.  The first is
 `get_dbg_preflist` which returns a list of `{{Index, Node}, Obj}`.
 That is it shows the mapping of vnodes to their respective values.
 The second function is `dbg_op` which allows me to fake partitioned
-writes.  A partitioned write is one that does not reach all it's
+writes.  A partitioned write is one that does not reach all its
 destination vnodes.
 
 ### Node Goes Down ###
@@ -839,7 +839,7 @@ occurring, should be no different from a single failure as long as the
 number of failures is less than `N`.  Once you lose `N` or more nodes
 you **may** start to lose **some** of your data.  This depends on how
 many nodes you have in the cluster and what the ring partition
-ownership looks like.  Essentially, for data to be lost, it's top `N`
+ownership looks like.  Essentially, for data to be lost, its top `N`
 partitions need to be owned by failed nodes.
 
 ### Partitioned Writes ###
@@ -1011,9 +1011,9 @@ Conflict resolution is not limited to just read time.  It's also
 needed during write time if there is a chance that the objects could
 be out of sync.  Think about hinted handoff for a second.  Hinted
 handoff occurs when a fallback vnode realizes the primary vnode is
-online and it's data can be transferred.  However there is a lag
+online and its data can be transferred.  However there is a lag
 between the time a fallback vnode recognizes the primary is online and
-when it starts transferring it's data.  During this window writes may
+when it starts transferring its data.  During this window writes may
 occur on the primary.  If that is the case then the handoff data
 cannot simply overwrite the local data or else data would be lost
 **locally**.  I emphasize locally because we are talking about a
@@ -1079,6 +1079,6 @@ purpose of this post is as much to learn as it is to teach.
 
 For my next post I'm thinking of either digging into ways to test
 these systems with tools such as QuickCheck or maybe doing an overview
-of every module in Riak Core describing it's purpose.  If you have an
+of every module in Riak Core describing its purpose.  If you have an
 opinion, on anything here, please ping me on
 [twitter](http://twitter.com/#!/rzezeski).

--- a/2011/riak-core-conflict-resolution/rts/src/rts_entry_vnode.erl
+++ b/2011/riak-core-conflict-resolution/rts/src/rts_entry_vnode.erl
@@ -1,6 +1,6 @@
 %% @doc A vnode to crunch incoming log entries.  Attempt to match each
 %% log entry against a registry of regexps.  If a regexp matches then
-%% execute it's corresponding trigger function passing it the {Client,
+%% execute its corresponding trigger function passing it the {Client,
 %% Entry, Regexp} as well as the resulting match.  The trigger
 %% function can then choose to take an action such as update a
 %% statistic via the `rts_stat_vnode'.

--- a/2011/riak-core-first-multinode/README.md
+++ b/2011/riak-core-first-multinode/README.md
@@ -3,7 +3,7 @@ Riak Core, First Multinode
 
 Questions about Riak Core seem to be occurring with more frequency on the riak-users mailing list.  Recently [jnewlend](https://github.com/jnewland) threw up a [Riak Core template](https://github.com/websterclay/rebar_riak_core) to be used with [Rebar](https://github.com/basho/rebar).  I thought this was excellent work and ran with it.
 
-While I liked what Mr. Newland had started I felt it could use a little more meat on it's bones.  He created a template to create a Riak Core application but left it as an exercise to the user to do the rest such as build a "multinode" capable release.  With knowledge of Erlang, Rebar, and peeking at the Riak source code this is certainly doable but it's a real PITA when you just want to get something up and running.  I've started [my own fork](https://github.com/rzezeski/rebar_riak_core/tree/multinode) that allows one to standup a _multinode_ release fairly easily.
+While I liked what Mr. Newland had started I felt it could use a little more meat on its bones.  He created a template to create a Riak Core application but left it as an exercise to the user to do the rest such as build a "multinode" capable release.  With knowledge of Erlang, Rebar, and peeking at the Riak source code this is certainly doable but it's a real PITA when you just want to get something up and running.  I've started [my own fork](https://github.com/rzezeski/rebar_riak_core/tree/multinode) that allows one to standup a _multinode_ release fairly easily.
 
 Um, Ryan...What The Hell is Multinode?
 ----------

--- a/2011/riak-core-the-coordinator/README.md
+++ b/2011/riak-core-the-coordinator/README.md
@@ -184,9 +184,9 @@ Now that I've written a coordinator to handle requests to RTS I need to refactor
 
     rts:get ----> rts_stat_vnode:get (local)
 
-                                                               /--> stat_vnode@rts1
-    rts:get ----> rts_get_fsm:get ----> riak_stat_vnode:get --|---> stat_vnode@rts2
-                                                               \--> stat_vnode@rts3
+                                                              /--> stat_vnode@rts1
+    rts:get ----> rts_get_fsm:get ----> rts_stat_vnode:get --|---> stat_vnode@rts2
+                                                              \--> stat_vnode@rts3
 
 
 Instead of performing a synchronous request the `rts:get/2` function now calls the get coordinator and then waits for a response.

--- a/2011/riak-core-the-coordinator/rts/src/rts_entry_vnode.erl
+++ b/2011/riak-core-the-coordinator/rts/src/rts_entry_vnode.erl
@@ -1,6 +1,6 @@
 %% @doc A vnode to crunch incoming log entries.  Attempt to match each
 %% log entry against a registry of regexps.  If a regexp matches then
-%% execute it's corresponding trigger function passing it the {Client,
+%% execute its corresponding trigger function passing it the {Client,
 %% Entry, Regexp} as well as the resulting match.  The trigger
 %% function can then choose to take an action such as update a
 %% statistic via the `rts_stat_vnode'.

--- a/2011/riak-core-the-vnode/README.md
+++ b/2011/riak-core-the-vnode/README.md
@@ -35,7 +35,7 @@ What's a vnode, Anyways?
 
 * Typically many vnodes will run on each physical node
 
-* Each machine has a _vnode master_ who's purpose is to keep track of all active vnodes on it's node
+* Each machine has a _vnode master_ who's purpose is to keep track of all active vnodes on its node
 
 As you can see a vnode takes on a lot of responsibility.  Luckily, the good folks at Basho have already done most of the heavy lifting by providing a [vnode behavior](https://github.com/basho/riak_core/blob/master/src/riak_core_vnode.erl) which you code to.  If Erlang is like a foreign language to you than think of a _behavior_ like an _interface_ in that it declares callback functions that you must implement.  Furthermore, it provides a _container_ which implements the semantics of the behavior and makes calls into your callback module.  Kind of like how J2EE provides a web container and you simply code a Servlet, except way cooler.  By coding to a behavior you are free to focus on the problem you need to solve rather than how to implement a vnode.  That said, you can't do much if you don't understand the inputs and outputs of these callbacks.  That's why you're reading this.
 
@@ -103,7 +103,7 @@ return `{stop, NewState}` to bring the vnode down as well.
 Commands
 ----------
 
-All incoming requests become commands on your vnode.  For example, a _GET_ on Riak KV will end up in the [handle_command](https://github.com/basho/riak_kv/blob/1.0/src/riak_kv_vnode.erl#L259) defined in it's vnode.  For this reason, it might be easiest to start with the question:
+All incoming requests become commands on your vnode.  For example, a _GET_ on Riak KV will end up in the [handle_command](https://github.com/basho/riak_kv/blob/1.0/src/riak_kv_vnode.erl#L259) defined in its vnode.  For this reason, it might be easiest to start with the question:
 
 > What commands will I need to implement?
 
@@ -207,9 +207,9 @@ coverage command but for now you'll have to look at the code.
 Handoff
 ----------
 
-A _handoff_ occurs when a vnode realizes it's not on the proper node.  This will happen when a) the ring has changed because of addition/removal of a node or b) a node comes alive after it has been down.  Riak Core implements _hinted handoff_.  The "hint" is a piece of data that tells the partition where it's proper home is.  Periodically a "home check" is done which uses the hint to determine if the vnode is on the correct physical host.  If it isn't, then it will go into handoff mode transfering it's data to the correct vnode.
+A _handoff_ occurs when a vnode realizes it's not on the proper node.  This will happen when a) the ring has changed because of addition/removal of a node or b) a node comes alive after it has been down.  Riak Core implements _hinted handoff_.  The "hint" is a piece of data that tells the partition where its proper home is.  Periodically a "home check" is done which uses the hint to determine if the vnode is on the correct physical host.  If it isn't, then it will go into handoff mode transfering its data to the correct vnode.
 
-Implementing handoff seems hard on the surface but it's nothing to be afraid of.  The key thing to remember about handoff is it's purpose is to transfer data from one vnode to another.  Data transfer, that's it.  This means that you don't have to implement handoff if your vnode is purely computational.  Well, you should write the callbacks but they won't have to do anything.
+Implementing handoff seems hard on the surface but it's nothing to be afraid of.  The key thing to remember about handoff is its purpose is to transfer data from one vnode to another.  Data transfer, that's it.  This means that you don't have to implement handoff if your vnode is purely computational.  Well, you should write the callbacks but they won't have to do anything.
 
 The players in handoff are `is_empty/1`, `delete/1`, `handoff_starting/2`, `handoff_cancelled/1`, `encode_handoff_item/2`, `handle_handoff_data/2`, `handle_handoff_command/3`, and `handoff_finished/2`.
 
@@ -220,7 +220,7 @@ The players in handoff are `is_empty/1`, `delete/1`, `handoff_starting/2`, `hand
     Result      :: {true, NewState}
                  | {false, NewState}
 
-Once the container has determined a vnode is out of place it's first action is determine if there is any data to be transferred.  If there is then return _true_ otherwise return _false_.  When a vnode is deemed empty the `delete/3` callback will be invoked.
+Once the container has determined a vnode is out of place its first action is determine if there is any data to be transferred.  If there is then return _true_ otherwise return _false_.  When a vnode is deemed empty the `delete/3` callback will be invoked.
 
 The stat vnode checks the size of the `stats` dict to determine if it's empty.
 
@@ -245,7 +245,7 @@ The container will invoke this callback when it's determined there is no more da
     State       :: term()
     NewState    :: term()
 
-Invoked by the container when it's determined a handoff must occur.  The vnode has the final say in whether or not the handoff will occur.  Return _true_ to continue and _false_ to cancel.  A vnode might have some heuristic that determines it's load and choose not to participate in handoff if overloaded at the moment.  The `TargetNode` is the node to transfer the data to.
+Invoked by the container when it's determined a handoff must occur.  The vnode has the final say in whether or not the handoff will occur.  Return _true_ to continue and _false_ to cancel.  A vnode might have some heuristic that determines its load and choose not to participate in handoff if overloaded at the moment.  The `TargetNode` is the node to transfer the data to.
 
 ### handoff_cancelled(State) -> Result ###
 
@@ -322,7 +322,7 @@ In the case of the stat vnode I'm using a [dict](http://www.erlang.org/doc/man/d
         Acc = dict:fold(Fun, Acc0, State#state.stats),
         {reply, Acc, State}.
 
-I do wonder if this fold request should have been it's own callback in the vnode behavior, but that's discussion for another day.
+I do wonder if this fold request should have been its own callback in the vnode behavior, but that's discussion for another day.
 
 
 ### handoff_finished(TargetNode, State) -> Result ###
@@ -405,5 +405,5 @@ When using Riak Core you must remember that it's a _tool_ for writing distribute
 Other Examples
 ----------
 
-Current examples of [Riak Core](https://github.com/basho/riak_core)  in action include [Riak KV](https://github.com/basho/riak_kv) (also just called Riak), [Riak Search](https://github.com/basho/riak_search) and [BashoBanjo](https://github.com/rklophaus/BashoBanjo).  The first two are actual products created and supported by Basho and the third is just something really cool that Rusty Klophaus did.
+Current examples of [Riak Core](https://github.com/basho/riak_core)  in action include [Riak KV](https://github.com/basho/riak_kv) (also just called Riak), [Riak Search](https://github.com/basho/riak_search) and [BashoBanjo](https://github.com/rustyio/BashoBanjo).  The first two are actual products created and supported by Basho and the third is just something really cool that Rusty Klophaus did.
 

--- a/2011/riak-core-the-vnode/rts/src/rts_entry_vnode.erl
+++ b/2011/riak-core-the-vnode/rts/src/rts_entry_vnode.erl
@@ -1,6 +1,6 @@
 %% @doc A vnode to crunch incoming log entries.  Attempt to match each
 %% log entry against a registry of regexps.  If a regexp matches then
-%% execute it's corresponding trigger function passing it the {Client,
+%% execute its corresponding trigger function passing it the {Client,
 %% Entry, Regexp} as well as the resulting match.  The trigger
 %% function can then choose to take an action such as update a
 %% statistic via the `rts_stat_vnode'.

--- a/2011/riak-search-inline-fields/README.md
+++ b/2011/riak-search-inline-fields/README.md
@@ -37,7 +37,7 @@ To properly understand inline fields you need to understand the
 _inverted index_ data structure <sup>3</sup>.  As a quick refresher
 the gist is that the index is a map from words to a list of document
 reference/weight pairs.  For each word <sup>4</sup> the index tells
-you in which documents it occurs and it's "weight" in relation to that
+you in which documents it occurs and its "weight" in relation to that
 document, e.g. how many times it occurs.  Search adds a little twist
 to this data structure by allowing an arbitrary list of properties to
 be tacked on to each of these pairs.  For example, Search tracks the
@@ -199,7 +199,7 @@ do how they relate to each other.  In the following table I show the
 performance increase of using the scoped filter query versus the other
 queries.  For example, the scoped filter query has three times the
 throughput and returns in 1/12th of the time, on average, as compared
-to the scoped query.  That is, even it's closest competitor has a
+to the scoped query.  That is, even its closest competitor has a
 latency profile that is an order of magnitude worse.  You may find it
 odd that I included the naive queries in this comparison but I wanted
 to show just how great the difference can be when you don't limit your


### PR DESCRIPTION
Rusty moved his repository, so a fixed link to BashoBanjo.

All the rest are "it's" that should be "its" (I was going to ignore them, honest, but since the link needed a fix anyway...).
